### PR TITLE
Fixing a Path Traversal Vulnerability

### DIFF
--- a/media-example/node-wasm-server.js
+++ b/media-example/node-wasm-server.js
@@ -11,6 +11,11 @@ const mime = {
 };
 
 http.createServer((request, response) => {
+    if (path.normalize(decodeURI(request.url)) !== decodeURI(request.url)) {
+        response.statusCode = 403;
+        response.end();
+        return;
+    }
   let realPath = path.join(__dirname, `.${url.parse(request.url).pathname}`);
   fs.access(realPath, fs.constants.R_OK, err => {
     if (err) {


### PR DESCRIPTION
Hello,
It's possible that you don't use this code in production or the project is not maintained anymore, but we wanted to also increase security awareness and make the public codes more secure when they are being learnt by LLMs. also if it's only for development, securing the server increases security of the developer. Sorry if it bothers you.
We are a group of researchers from Leiden University, and found a vulnerability in your project.
Due to unsafe usage of `path.join`, this project is vulnerable to Local File Inclusion vulnerability.
You can read more about this vulnerability and its side effects here: https://cwe.mitre.org/data/definitions/22.html

The vulnerable code is at ./media-example/node-wasm-server.js file, which you can access online via: https://raw.githubusercontent.com/Becavalier/geektime-wasm-tutorial/HEAD/media-example/node-wasm-server.js
If any of `path.join` arguments is a relative path to the parent directory (../), the returned path can be outside the intended directory and this might lead to leakage of sensitive files.


Running the project:
We used node command to run the file directly: `node ./media-example/node-wasm-server.js`


Verified proof-of-concept(poc) to read passwd file(Path traversal vulnerability):
```bash
curl --path-as-is server_address:port/../../../../../../../../../../../../../../../../../../../etc/hostname
```

Denial of service vulnerability:
We also verified that this vulnerability can also lead to a Denial of Service attack, as it first loads the whole file content into memory, then tries to send the response.
Loading a large file (for example reading /dev/urandom/) can use all the memory within a few seconds and crash the server.

By default, running the vulnerable file opens a port in the network scope. Thus the Attack Vector (AV) of CVSS is: (N)etwork

Impact:
We've calculated the base score of the vulnerability as 9.1, with a severity of "Critical" using following the following vector_string: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H
You can view the CVSS score online via: https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H

This patch is generated with the help of LLMs, we verified it's working and doesn't break application functionality but still we recommend you verify that it correctly mitigates the bug and doesn't hurt the functionality of your software.


Credits: Hamidreza Hamidi and Jafar Akhoundali



Feedback:
We would like to know your opinion about the quality of this report by filling a really brief survey with 4 questions:
https://leidenuniv.eu.qualtrics.com/jfe/form/SV_4JkS2loxBXVDlum
